### PR TITLE
Change the file type for .tsc to typescript.tsx

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@
 Neovim nightly
 
 ## Change logs
+Sat May 15 15:18:50 PDT 2021
+- Changed the `filetype` of `tsc` from `typescriptreact` (default) to `typescript.tsx` to fix the auto-indent
+
 Sun Apr 11 18:31:02 PDT 2021
 - auto reload when there are external changes
 

--- a/init.vim
+++ b/init.vim
@@ -1,5 +1,10 @@
 " leader key
 let g:mapleader = ","
+" filetype for tsx
+let g:coc_filetype_map = {
+  \ 'tsx': 'typescript.tsx',
+  \ }
+autocmd bufnewfile,bufread *.tsx set filetype=typescript.tsx
 
 " Plugins
 source ~/.config/nvim/plugins/init.vim
@@ -36,6 +41,3 @@ set softtabstop=2
 set expandtab
 set smarttab
 
-" auto reload buffers
-set autoread
-au FocusGained,BufEnter * :checktime


### PR DESCRIPTION
### Description

There are some issues with the auto indention for the default file type `typescriptreact` for tsc. Changed the filetype from `typescriptreact` to `typescript.tsx`.
