### PR TITLE
Cache aireline highlight

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@
 Neovim nightly
 
 ## Change logs
+Tue May 18 16:43:07 PDT 2021
+- Optimized the speed of switching between splits
+
 Sat May 15 15:18:50 PDT 2021
 - Changed the `filetype` of `tsc` from `typescriptreact` (default) to `typescript.tsx` to fix the auto-indent
 

--- a/init.vim
+++ b/init.vim
@@ -6,6 +6,9 @@ let g:coc_filetype_map = {
   \ }
 autocmd bufnewfile,bufread *.tsx set filetype=typescript.tsx
 
+" vim-airline optimization, https://github.com/vim-airline/vim-airline/issues/1526
+let g:airline_highlighting_cache=1
+
 " Plugins
 source ~/.config/nvim/plugins/init.vim
 


### PR DESCRIPTION
### Description
Switching between splits slows down after a while which is probably caused by the airline plugin.

### Details

Turned on the cache for airline highlighting as suggested in https://github.com/vim-airline/vim-airline/issues/1526


### Related
https://github.com/vim-airline/vim-airline/issues/1526
https://stackoverflow.com/questions/12213597/how-to-see-which-plugins-are-making-vim-slow
